### PR TITLE
145 move current date and getctxpayments by month call to context

### DIFF
--- a/bookkeeping-app/src/components/contexts/RentPaymentsCtx.jsx
+++ b/bookkeeping-app/src/components/contexts/RentPaymentsCtx.jsx
@@ -28,7 +28,8 @@ export function RentPaymentsCtxProvider(props) {
     const { ctxAccessToken } = useContext(AuthCtx);
     const { ctxActiveProperty } = useContext(PropertiesCtx);
 
-    const prevDateRef = useRef({ month: null, year: null });
+    // propertyId is to trigger fetch if property changes
+    const prevDateRef = useRef({ month: null, year: null, propertyId: null });
 
     const [ctxPaymentList, setCtxPaymentList] = useState([]);
     const [ctxMonthPaymentList, setCtxMonthPaymentList] = useState([]);
@@ -48,8 +49,11 @@ export function RentPaymentsCtxProvider(props) {
         const currentMonth = ctxActiveDate.getMonth();
         const currentYear = ctxActiveDate.getFullYear();
 
-        if (prevDateRef.current.month !== currentMonth || prevDateRef.current.year !== currentYear) {
-            console.log("Date changed, fetching new data.");
+        if (
+            prevDateRef.current.month !== currentMonth ||
+            prevDateRef.current.year !== currentYear ||
+            prevDateRef.current.propertyId !== ctxActiveProperty.id
+        ) {
             getCtxPaymentsByMonth(currentMonth + 1, currentYear);
         }
 

--- a/bookkeeping-app/src/pages/RentsPage.jsx
+++ b/bookkeeping-app/src/pages/RentsPage.jsx
@@ -46,10 +46,6 @@ const RentsPage = () => {
         gridTemplateRows: daysOverflow ? "repeat(6, 1fr)" : "repeat(5, 1fr)",
     };
 
-    useEffect(() => {
-        getCtxPaymentsByMonth(currentMonth + 1, currentYear);
-    }, [currentMonth, currentYear]);
-
     const getDaysInMonth = (year, month) => {
         return new Date(year, month + 1, 0).getDate();
     };


### PR DESCRIPTION
# Changes
- Moves useEffect fetch call to context
- Added ref to have more consistent date tracking
- Used ref to introduce checks to ensure fetches of payments are only done on refresh, load, change of date, and change of property