### PR TITLE
Changed tests to function with new strategies and component changes

### DIFF
--- a/bookkeeping-app/__tests__/components/contexts/AuthCtx.test.jsx
+++ b/bookkeeping-app/__tests__/components/contexts/AuthCtx.test.jsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { useContext } from "react";
 
 import { AuthCtxProvider } from "@/src/contexts/AuthCtx";
 import AuthCtx from "@/src/contexts/AuthCtx";
+import { configureApiClient } from "@/src/Client";
 import { api } from "@/src/Client";
 
 jest.mock("@/src/Client", () => ({
@@ -22,6 +23,7 @@ const TestComponent = () => {
     const ctx = useContext(AuthCtx);
     return (
         <div>
+            <span data-testid="loading">{String(ctx.ctxAuthLoading)}</span>
             <span data-testid="token">{ctx.ctxAccessToken || ""}</span>
             <span data-testid="email">{ctx.ctxUserData?.email || ""}</span>
             <button onClick={() => ctx.setCtxAccessToken("new-token")}>Set Token</button>
@@ -33,45 +35,72 @@ const TestComponent = () => {
 describe("AuthCtx", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        localStorage.clear();
     });
 
-    test("hydrates token from localStorage", async () => {
-        localStorage.setItem("accessToken", "stored-token");
+    test("hydrates auth from refresh + profile bootstrap", async () => {
+        api.post.mockResolvedValueOnce({});
         api.get.mockResolvedValueOnce({ email: "stored@test.com" });
+
         wrap(<TestComponent />);
-        expect(screen.getByTestId("token")).toHaveTextContent("stored-token");
-        await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/profile/"));
+
+        expect(screen.getByTestId("loading")).toHaveTextContent("true");
+
+        await waitFor(() => {
+            expect(api.post).toHaveBeenCalledWith("/api/auth/refresh/", {}, { authRequired: false });
+            expect(api.get).toHaveBeenCalledWith("/api/profile/");
+            expect(screen.getByTestId("token")).toHaveTextContent("cookie-session");
+            expect(screen.getByTestId("email")).toHaveTextContent("stored@test.com");
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
     });
 
-    test("fetches profile when token exists", async () => {
-        localStorage.setItem("accessToken", "stored-token");
+    test("configures api client and unauthorized handler clears auth state", async () => {
+        api.post.mockResolvedValueOnce({});
         api.get.mockResolvedValueOnce({ email: "user@test.com" });
 
         wrap(<TestComponent />);
 
-        await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/profile/"));
-        expect(screen.getByTestId("email")).toHaveTextContent("user@test.com");
+        await waitFor(() => expect(screen.getByTestId("token")).toHaveTextContent("cookie-session"));
+
+        const latestConfigCall = configureApiClient.mock.calls.at(-1)[0];
+        expect(latestConfigCall.tokenGetter()).toBe("cookie-session");
+
+        act(() => {
+            latestConfigCall.unauthorizedHandler();
+        });
+        await waitFor(() => {
+            expect(screen.getByTestId("token")).toHaveTextContent("");
+            expect(screen.getByTestId("email")).toHaveTextContent("");
+        });
     });
 
-    test("clears user data when profile call fails", async () => {
-        localStorage.setItem("accessToken", "stored-token");
-        api.get.mockRejectedValueOnce(new Error("boom"));
+    test("refresh failure clears auth state and ends loading", async () => {
+        api.post.mockRejectedValueOnce(new Error("boom"));
 
         wrap(<TestComponent />);
 
-        await waitFor(() => expect(api.get).toHaveBeenCalled());
-        expect(screen.getByTestId("email")).toHaveTextContent("");
+        await waitFor(() => {
+            expect(api.get).not.toHaveBeenCalled();
+            expect(screen.getByTestId("token")).toHaveTextContent("");
+            expect(screen.getByTestId("email")).toHaveTextContent("");
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
     });
 
-    test("setting token triggers profile fetch", async () => {
+    test("setting token reconfigures api client token getter", async () => {
+        api.post.mockResolvedValueOnce({});
         api.get.mockResolvedValueOnce({ email: "new@test.com" });
+
         wrap(<TestComponent />);
+
+        await waitFor(() => expect(screen.getByTestId("token")).toHaveTextContent("cookie-session"));
 
         fireEvent.click(screen.getByText("Set Token"));
 
-        await waitFor(() => expect(api.get).toHaveBeenCalledWith("/api/profile/"));
-        expect(screen.getByTestId("email")).toHaveTextContent("new@test.com");
+        await waitFor(() => {
+            const latestConfigCall = configureApiClient.mock.calls.at(-1)[0];
+            expect(latestConfigCall.tokenGetter()).toBe("new-token");
+        });
     });
 });
 

--- a/bookkeeping-app/__tests__/components/elements/modals/LoginModal.test.jsx
+++ b/bookkeeping-app/__tests__/components/elements/modals/LoginModal.test.jsx
@@ -3,14 +3,12 @@
  *
  */
 
-import { render, screen, fireEvent,waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import LoginModal from "@/src/components/elements/modals/LoginModal";
-import AuthCtx from "@/src/contexts/AuthCtx";
+import { useAuth } from "@/src/hooks/useAuth";
 
-// Mocking enviroment variables
-jest.mock("@/src/constants", () => ({
-    ENVIRONMENT: "test",
-    BASE_URL: "http://test-url.com",
+jest.mock("@/src/hooks/useAuth", () => ({
+    useAuth: jest.fn(),
 }));
 
 const mockNavigate = jest.fn();
@@ -18,38 +16,23 @@ jest.mock("react-router-dom", () => ({
     useNavigate: () => mockNavigate,
 }));
 
-// Define placeholder for global.fetch if not already defined
-if (typeof global.fetch === "undefined") {
-    global.fetch = jest.fn();
-}
-
-const mockFetch = jest.spyOn(global, "fetch");
-const localStorageSetItem = jest.fn();
-Object.defineProperty(window, "localStorage", {
-    value: {
-        setItem: localStorageSetItem,
-    },
-    writable: true,
-});
-let consoleErrorSpy;
-
-// Mocking context provider
-const mockSetAccessToken = jest.fn();
+const mockLogin = jest.fn();
 const mockRequestPswdReset = jest.fn();
-const MockAuthsCtxProvider = ({ children }) => (
-    <AuthCtx.Provider value={{ setCtxAccessToken: mockSetAccessToken, requestPswdReset: mockRequestPswdReset }}>
-        {children}
-    </AuthCtx.Provider>
-);
 
 const mockHandleCloseModal = jest.fn();
 const mockSwitchModal = jest.fn();
 // Functon to create a login modal with context and props
 const renderLoginModal = () => {
+    mockLogin.mockResolvedValue({ success: false, message: "" });
+    mockRequestPswdReset.mockResolvedValue({ success: true, message: "Success!" });
+
+    useAuth.mockReturnValue({
+        login: mockLogin,
+        requestPswdReset: mockRequestPswdReset,
+    });
+
     return render(
-        <MockAuthsCtxProvider>
-            <LoginModal handleCloseModal={mockHandleCloseModal} switchModal={mockSwitchModal} />
-        </MockAuthsCtxProvider>
+        <LoginModal handleCloseModal={mockHandleCloseModal} switchModal={mockSwitchModal} />
     );
 };
 
@@ -143,8 +126,6 @@ describe("LoginModal password reset link", () => {
 describe("LoginModal handleLogin functionality", () => {
     const testEmail = "test@user.com";
     const testPassword = "password123";
-    const testAccessToken = "mock.jwt.access.token";
-    const apiUrl = "http://test-url.com/api/auth/jwt/create/";
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -152,19 +133,12 @@ describe("LoginModal handleLogin functionality", () => {
 
         fireEvent.change(screen.getByTestId("input-email"), { target: { value: testEmail } });
         fireEvent.change(screen.getByTestId("input-password"), { target: { value: testPassword } });
-
-        // Spy on console.error but replace with empty function
-        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-    });
-
-    afterEach(() => {
-        consoleErrorSpy.mockRestore();
     });
 
     it("should handle successful login (200 OK)", async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ access: testAccessToken, refresh: "mock.refresh.token" }),
+        mockLogin.mockResolvedValueOnce({
+            success: true,
+            message: "Login successful.",
         });
 
         const loginButton = screen.getByRole("button", { name: /login/i });
@@ -173,25 +147,17 @@ describe("LoginModal handleLogin functionality", () => {
             fireEvent.click(loginButton);
         });
 
-        expect(mockFetch).toHaveBeenCalledWith(apiUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ username: testEmail, password: testPassword }),
-        });
-
         await waitFor(() => {
-            expect(localStorageSetItem).toHaveBeenCalledWith("accessToken", testAccessToken);
-            expect(mockSetAccessToken).toHaveBeenCalledWith(testAccessToken);
+            expect(mockLogin).toHaveBeenCalledWith(testEmail, testPassword);
+            expect(screen.getByText("Login successful.")).toBeInTheDocument();
             expect(mockNavigate).toHaveBeenCalledWith("/app/home");
-            expect(mockHandleCloseModal).toHaveBeenCalledTimes(1);
         });
     });
 
     it("should handle login failure (non-ok response, e.g., 401)", async () => {
-        mockFetch.mockResolvedValueOnce({
-            ok: false,
-            status: 401,
-            json: async () => ({ detail: "Invalid credentials" }),
+        mockLogin.mockResolvedValueOnce({
+            success: false,
+            message: "Invalid credentials",
         });
 
         const loginButton = screen.getByRole("button", { name: /login/i });
@@ -201,15 +167,17 @@ describe("LoginModal handleLogin functionality", () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByText("Login failed please try again.")).toBeInTheDocument();
-            expect(localStorageSetItem).not.toHaveBeenCalled();
+            expect(mockLogin).toHaveBeenCalledWith(testEmail, testPassword);
+            expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
             expect(mockNavigate).not.toHaveBeenCalled();
-            expect(mockHandleCloseModal).not.toHaveBeenCalled();
         });
     });
 
     it("should handle network failure (.catch block)", async () => {
-        mockFetch.mockRejectedValueOnce(new Error("Network Error"));
+        mockLogin.mockResolvedValueOnce({
+            success: false,
+            message: "A network error occurred. Please try again.",
+        });
 
         const loginButton = screen.getByRole("button", { name: /login/i });
 
@@ -218,8 +186,8 @@ describe("LoginModal handleLogin functionality", () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByText("Login failed please try again.")).toBeInTheDocument();
-            expect(localStorageSetItem).not.toHaveBeenCalled();
+            expect(mockLogin).toHaveBeenCalledWith(testEmail, testPassword);
+            expect(screen.getByText("A network error occurred. Please try again.")).toBeInTheDocument();
         });
     });
 });

--- a/bookkeeping-app/__tests__/components/elements/modals/LogoutModal.test.jsx
+++ b/bookkeeping-app/__tests__/components/elements/modals/LogoutModal.test.jsx
@@ -5,12 +5,10 @@
 
 import { render, screen, fireEvent } from "@testing-library/react";
 import LogoutModal from "@/src/components/elements/modals/LogoutModal";
-import AuthCtx from "@/src/contexts/AuthCtx";
+import { useAuth } from "@/src/hooks/useAuth";
 
-// Mocking enviroment variables
-jest.mock("@/src/constants", () => ({
-    ENVIRONMENT: "test",
-    BASE_URL: "http://test-url.com",
+jest.mock("@/src/hooks/useAuth", () => ({
+    useAuth: jest.fn(),
 }));
 
 const mockNavigate = jest.fn();
@@ -18,17 +16,11 @@ jest.mock("react-router-dom", () => ({
     useNavigate: () => mockNavigate,
 }));
 
-const mockLogoutUser = jest.fn();
-const MockAuthsCtxProvider = ({ children }) => (
-    <AuthCtx.Provider value={{ logoutUser: mockLogoutUser }}>{children}</AuthCtx.Provider>
-);
+const mockLogout = jest.fn();
 
 const renderLogoutModal = () => {
-    return render(
-        <MockAuthsCtxProvider>
-            <LogoutModal />
-        </MockAuthsCtxProvider>
-    );
+    useAuth.mockReturnValue({ logout: mockLogout });
+    return render(<LogoutModal />);
 };
 
 describe("LoginModal render and functionality", () => {
@@ -43,11 +35,11 @@ describe("LoginModal render and functionality", () => {
         expect(screen.queryByText("Back to Login")).toBeInTheDocument();
     });
 
-    it("should call logoutUser() and navigate the user back to the splash page", () => {
+    it("should call logout() and navigate the user back to the splash page", () => {
         const logoutButton = screen.queryByText("Back to Login");
         fireEvent.click(logoutButton);
 
-        expect(mockLogoutUser).toHaveBeenCalledTimes(1);
+        expect(mockLogout).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith("/");
     });
 });

--- a/bookkeeping-app/src/components/elements/modals/AddAccountModal.jsx
+++ b/bookkeeping-app/src/components/elements/modals/AddAccountModal.jsx
@@ -7,6 +7,7 @@ import AddInputCluster from "../utilities/AddInputCluster";
 import upChevIcon from "../../../assets/chevron-up-icon.svg";
 import downChevIcon from "../../../assets/chevron-down-icon.svg";
 import NoResultsDisplay from "../utilities/NoResultsDisplay";
+import AccountsCtx from "../../../contexts/AccountsCtx";
 
 const AddAccountModal = ({ handleCloseModal }) => {
     const { ctxAddAccount, ctxGetNonPropertyAccounts } = useContext(AccountsCtx);


### PR DESCRIPTION
This pull request updates tests for authentication-related modal components to use the new `useAuth` hook instead of the legacy `AuthCtx` context, and improves test coverage for authentication flows. The changes modernize the test setup, improve mocking, and ensure more accurate and maintainable tests for login, logout, and authentication context behaviors.

